### PR TITLE
Normalize tangent and bitangent

### DIFF
--- a/cotangent-frame.glsl
+++ b/cotangent-frame.glsl
@@ -14,7 +14,7 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
 
   // construct a scale-invariant frame 
   float invmax = 1.0 / sqrt(max(dot(T,T), dot(B,B)));
-  return mat3(T * invmax, B * invmax, N);
+  return mat3(normalize(T * invmax), normalize(B * invmax), N);
 }
 
 #pragma glslify: export(cotangentFrame)


### PR DESCRIPTION
Without normalization we run into artefacts on curved meshes.

```glsl
return mat3(normalize(T * invmax), normalize(B * invmax), N)
```

![screen shot 2018-08-22 at 15 18 22](https://user-images.githubusercontent.com/171001/44473148-98a9cb80-a627-11e8-94a4-ed8983c1821d.jpg)
